### PR TITLE
Update RecordList.php

### DIFF
--- a/Classes/RecordList.php
+++ b/Classes/RecordList.php
@@ -28,11 +28,7 @@ class RecordList extends \TYPO3\CMS\Recordlist\RecordList {
 	 */
 	public function __construct() {
 		parent::__construct();
-
-		$GLOBALS['TBE_TEMPLATE']->getPageRenderer()->addJsInlineCode('typo3_version', 'var sg_t3version="' . TYPO3_version . '";');
-		$GLOBALS['TBE_TEMPLATE']->getPageRenderer()->loadJquery();
-		$GLOBALS['TBE_TEMPLATE']->getPageRenderer()->loadRequireJs();
-		$GLOBALS['TBE_TEMPLATE']->getPageRenderer()->addJsFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('listview_dnd') . 'Resources/Public/JavaScript/dnd.js');
+		$GLOBALS['TBE_TEMPLATE']->loadJavascriptLib(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('listview_dnd') . 'Resources/Public/JavaScript/dnd.js');
 	}
 }
 


### PR DESCRIPTION
Remove deprecated methods to match TYPO3 8.x API. Also remove check for version - so this works for 8.x only. Target is to make this work in TYPO3 8.x, tested in 8.7.3. 